### PR TITLE
README: Add "Requires PHP" header

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -5,6 +5,7 @@ Tags: debugbar, debug-bar, Debug Bar, Post Types, Debug Bar Post Types, Custom P
 Requires at least: 3.4
 Tested up to: 4.8
 Stable tag: 1.4.0
+Requires PHP: 5.2.4
 Depends: Debug Bar
 License: GPLv2
 


### PR DESCRIPTION
This new header has been soft launched on August 25th 2017.

Refs:
* https://meta.trac.wordpress.org/ticket/2952
* https://meta.trac.wordpress.org/changeset/5841

https://wordpress.org/plugins/developers/readme-validator/